### PR TITLE
fix: Hotfixes - relationship names and data overwriting

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -1,4 +1,5 @@
 import re
+import time
 import numpy as np
 import pandas as pd
 from streamlit_gsheets import GSheetsConnection
@@ -32,6 +33,7 @@ class Data:
     def update(self, data=None):
         if data is not None:
             self.conn.update(worksheet=self.worksheet, data=data)
+            time.sleep(1)
             self.read()
 
     @property

--- a/src/data_funcs.py
+++ b/src/data_funcs.py
@@ -159,7 +159,7 @@ def get_relationship(start_id: int, end_id: int) -> str:
     if min_dist == 3:
         s += "Second "
     if min_dist == 4:
-        s += "third "
+        s += "Third "
     if min_dist == 5:
         s += f"{min_dist - 1}th "
     s += "Cousin"
@@ -167,10 +167,10 @@ def get_relationship(start_id: int, end_id: int) -> str:
     if removed == 0:
         return s
     if removed == 1:
-        s += " once removed"
+        s += " Once Removed"
         return s
     if removed == 2:
-        s += " twice removed"
+        s += " Twice Removed"
         return s
-    s += f"{removed} times remove"
+    s += f" {removed} Times Removed"
     return s


### PR DESCRIPTION
Fixed the naming of relatives

Added a 1 second delay between updating data and reading new data. I hope that this will prevent overwriting of the data in future